### PR TITLE
Fix group selection order in access control

### DIFF
--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -34,8 +34,9 @@
 		onChange(accessControl);
 	}
 
-	onMount(async () => {
-		groups = await getGroups(localStorage.token);
+        onMount(async () => {
+                groups = await getGroups(localStorage.token);
+                groups.sort((a, b) => a.name.localeCompare(b.name));
 
 		if (accessControl === null) {
 			if (allowPublic) {


### PR DESCRIPTION
## Summary
- sort the groups alphabetically when building the access control dropdown

## Testing
- `npm run lint` *(fails: ESLint config and dependencies missing)*